### PR TITLE
1.1.1: Issue #21: Wait for TTS to complete

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -12,7 +12,7 @@ Copyright 2015, 2019, 2020, 2021 Google LLC. All Rights Reserved.
  limitations under the License.
 */
 
-const OFFLINE_VERSION = 10010;
+const OFFLINE_VERSION = 10101;
 
 const CACHE_NAME = 'offline';
 

--- a/src/js/i18n/strings_en.js
+++ b/src/js/i18n/strings_en.js
@@ -14,7 +14,7 @@ along with Scale Tutor.  If not, see <http://www.gnu.org/licenses/>.
 */
 const strings_en = {
     "app_name": "Scale Tutor",
-    "app_version": "1.1.0",
+    "app_version": "1.1.1",
     "about_copyright": "Copyright (c) 2021 - present, Carmen Alvarez",
     "about_contact": "carmen@rmen.ca",
     "about_source_code": "Source code",

--- a/src/js/model/MainModel.js
+++ b/src/js/model/MainModel.js
@@ -30,7 +30,9 @@ class MainModel {
 
     playText(text) {
         if (this._settings.isSpeechSynthesisEnabled()) {
-            this._speechEngine.playText(text, this._settings.getVolume())
+            return this._speechEngine.playText(text, this._settings.getVolume())
+        } else {
+            return Promise.resolve()
         }
     }
 

--- a/src/js/model/ScalePlayer.js
+++ b/src/js/model/ScalePlayer.js
@@ -40,7 +40,6 @@ class ScalePlayer {
 
     playScale(scale, tempoBpm, transposition, rhythm) {
         const noteDurationS = 60 / tempoBpm
-        const ttsDurationS = 2
         const preparationBeepsDurationS = 4 * noteDurationS
         Log.log(this._tag, "playScale, context = " + this._context)
         if (!this._context) {
@@ -54,15 +53,15 @@ class ScalePlayer {
             for (let i = 0; i < 4; i++) {
                 oscillator.frequency.setValueAtTime(
                     scale.startingNote.getNote(transposition).frequency(),
-                    this._context.currentTime + ttsDurationS + (i * noteDurationS))
+                    this._context.currentTime + (i * noteDurationS))
                 oscillator.frequency.setValueAtTime(
                     0,
-                    this._context.currentTime + ttsDurationS + (i * noteDurationS) + (noteDurationS / 2))
+                    this._context.currentTime + (i * noteDurationS) + (noteDurationS / 2))
             }
 
             // Schedule the scale notes
             const noteStartTimes = this._getNoteStartTimes(scale, noteDurationS, rhythm)
-                .map(item => item + this._context.currentTime + ttsDurationS + preparationBeepsDurationS)
+                .map(item => item + this._context.currentTime + preparationBeepsDurationS)
             scale.halfSteps.map(halfStep => scale.startingNote.getNote(halfStep + transposition))
                 .filter(note => note != undefined)
                 .forEach((note, index) => {
@@ -81,7 +80,7 @@ class ScalePlayer {
             this._gainNode = this._context.createGain()
             this._gainNode.gain.value = this._volume
             oscillator.connect(this._gainNode).connect(this._context.destination)
-            oscillator.start(this._context.currentTime + ttsDurationS)
+            oscillator.start(this._context.currentTime)
             oscillator.stop(restEndTime)
             oscillator.onended = () => {
                 this._isPlaying = false

--- a/src/js/model/SpeechEngine.js
+++ b/src/js/model/SpeechEngine.js
@@ -22,11 +22,13 @@ class SpeechEngine {
         this._synth = window.speechSynthesis
     }
 
-    playText(text, volume) {
+    playText = (text, volume) => new Promise(completionFunc => {
         const speechSynthesisUtterance = new SpeechSynthesisUtterance(text)
         speechSynthesisUtterance.lang = "en-US"
         speechSynthesisUtterance.volume = volume
+        speechSynthesisUtterance.onend = completionFunc
+        speechSynthesisUtterance.onerror = completionFunc
         this._synth.speak(speechSynthesisUtterance)
-    }
+    })
 
 }

--- a/src/js/viewmodel/MainViewModel.js
+++ b/src/js/viewmodel/MainViewModel.js
@@ -211,8 +211,10 @@ class MainViewModel {
                 this._updateScaleDisplay(scale)
                 break;
             case StateMachine.State.SPEAK_SCALE_NAME:
-                this._model.playText(this._getTtsText(scale))
                 this.isPlayingState.value = true
+                this._model.playText(this._getTtsText(scale)).then(() =>{
+                    this._stateMachine.doAction(StateMachine.Action.SPEAK_SCALE_NAME_COMPLETED)
+                })
                 break;
             case StateMachine.State.PLAY_NOTES:
                 this._model.playScale(scale).then(() => {

--- a/src/js/viewmodel/StateMachine.js
+++ b/src/js/viewmodel/StateMachine.js
@@ -45,6 +45,8 @@ class StateMachine {
                 } else {
                     return StateMachine.State.PLAY_NOTES
                 }
+            case StateMachine.Action.SPEAK_SCALE_NAME_COMPLETED:
+                return StateMachine.State.PLAY_NOTES
             case StateMachine.Action.STOP:
                 return StateMachine.State.PLAY_INTERRUPTED
             default: /* PLAY_COMPLETED*/
@@ -55,8 +57,6 @@ class StateMachine {
         switch (this.state) {
             case StateMachine.State.AUTO_SCALE_DISPLAY:
                 return StateMachine.State.SPEAK_SCALE_NAME
-            case StateMachine.State.SPEAK_SCALE_NAME:
-                return StateMachine.State.PLAY_NOTES
             case StateMachine.State.PLAY_COMPLETE:
                 if (this.autoPlay) return StateMachine.State.AUTO_SCALE_DISPLAY
                 else return undefined
@@ -70,6 +70,7 @@ StateMachine.Action = Object.freeze({
     PREVIOUS: "previous",
     PLAY: "play",
     STOP: "stop",
+    SPEAK_SCALE_NAME_COMPLETED: "speak_scale_name_completed",
     PLAY_COMPLETED: "play_completed"
 })
 StateMachine.State = Object.freeze({


### PR DESCRIPTION
Remove the hardcoded 2-second pause from `ScalePlayer` that was used to estimate the time it would take for TTS to read the scale name.

Instead, wait for the scale name to be read completely, then play the notes.

#21